### PR TITLE
Support deleting messages and reactions

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -155,6 +155,8 @@ CACHES = {
     }
 }
 
+ROOM_NAME = 'index'
+
 # Activate Django-Heroku.
 import django_heroku
 django_heroku.settings(locals())

--- a/main/helpers.py
+++ b/main/helpers.py
@@ -1,0 +1,57 @@
+import json
+from contextlib import contextmanager
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.conf import settings
+from django.core.cache import cache
+
+
+@contextmanager
+def get_message_history():
+    """
+        Context manager to load and save state of previously received Slack messages. E.g.:
+
+            with get_message_history() as message_history:
+                # message_history is a list like
+                # [{'id':'...', 'image':'data', 'color':'#fff', 'reactions':['smile', 'red_circle']}]
+                # with the most recent message appearing last.
+                # Changes made to message_history inside this block will be persisted.
+    """
+    # load message history
+    orig_message_history = cache.get("message_history", "[]")
+    message_history = json.loads(orig_message_history)
+
+    yield message_history
+
+    # trim and save message_history if changed
+    message_history = message_history[-5:]
+    new_message_history = json.dumps(message_history)
+    if new_message_history != orig_message_history:
+        cache.set("message_history", new_message_history)
+
+def message_for_ts(message_history, ts):
+    """
+        Given list of messages and timestamp of desired message, return (message, is_last),
+        or (None, None) if not found.
+    """
+    return next((
+        (m, i==len(message_history)-1)
+        for i, m in enumerate(message_history)
+        if m['id'] == ts
+    ), (None, None))
+
+
+_state_keys = ('image', 'color')
+
+def send_state(state):
+    """ Send state to listeners. """
+    # filter state to just expected keys
+    state = {k:v for k, v in state.items() if k in _state_keys}
+
+    # send to settings.ROOM_NAME
+    channel_layer = get_channel_layer()
+    async_to_sync(channel_layer.group_send)(settings.ROOM_NAME, {
+        'type': 'share_state',
+        'state': state,
+    })

--- a/main/templates/index.html
+++ b/main/templates/index.html
@@ -8,14 +8,15 @@
   <link rel="stylesheet" href="{% static "css/styles.css" %}" type="text/css" />
 </head>
 <body>
-  <div id="app">
-    <img :src="encoded_image">
+  <div id="app" :style="'background-color:'+color">
+    <img v-if="image" :src="image">
   </div>
   <script>
     var app = new Vue({
       el: '#app',
       data: {
-        encoded_image: ""
+        image: null,
+        color: '#fff'
       }
     });
 
@@ -25,11 +26,10 @@
 
       socket.onmessage = function(e) {
         console.log("Got", e);
-        var message = JSON.parse(e.data);
-        if(message.type === "image")
-          app.encoded_image = message.data;
-        else if(message.type === "color")
-          document.body.style.backgroundColor = message.data;
+        var state = JSON.parse(e.data);
+        Object.keys(state).forEach(function(key) {
+          app[key] = state[key];
+        });
       };
 
       socket.onclose = function(e) {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,14 +1,14 @@
 /* add blank frame around picture */
 *{box-sizing: border-box;}
-body{
-    padding: 5%;  /* change to 0 if no frame desired */
-}
 
 /* make image fit to available space */
 html, body, #app{
     width: 100%;
     height: 100%;
     margin: 0;
+}
+#app{
+    padding: 5%;  /* change to 0 if no frame desired */
 }
 img {
     object-fit: contain;  /* change to "cover" to zoom until image covers whole frame */


### PR DESCRIPTION
Some general refactoring here so we have a list of the last five file uploads stored in Redis and track all of their reactions, which lets us restore previous state after a message is deleted, without letting the bot read channel history which I'm trying to avoid to limit the power of its credentials. As usual, overengineering screenshare for fun & profit.