### PR TITLE
ASCII art fire (attempt 1)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -188,3 +188,4 @@ LOGGING = {
     }
 }
 
+ASCII_FIRE_URL = env("ASCII_FIRE_URL")

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -16,3 +16,8 @@ html, body, #app{
     width: 100%;
     height: 100%;
 }
+
+/* make the ascii fire full-screen */
+#app:has(video.ascii-fire) {
+    padding: 0;
+}


### PR DESCRIPTION
Display an ascii-art fire video if :hotfire: is posted in a screenshare message's text.

Adds a setting, `ASCII_FIRE_URL = env("ASCII_FIRE_URL")`; will need to point it at the video I'm hosting in the env, however that works.

This is untested. Dare we try as is? If not, I'd appreciate strategizing about the easiest way to install and test locally.