### PR TITLE
Remove PIP_NO_BINARY=hiredis

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PIP_NO_BINARY=hiredis


### PR DESCRIPTION
See https://lil.law.harvard.edu/blog/2019/05/20/improving-pip-compile-generate-hashes/ -- it looks like [hiredis-py](https://github.com/redis/hiredis-py)'s release setup is better now.