### PR TITLE
Add primitive mechanism

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -197,3 +197,5 @@ AMBIENT_YOUTUBE_VIDEOS = {}
 for video in (v for k,v in env.ENVIRON.items() if k.startswith('AMBIENT_YOUTUBE_VIDEO')):
     emoji, config = json.loads(video)
     AMBIENT_YOUTUBE_VIDEOS[emoji] = config
+
+PRIMITIVE_URL = env("PRIMITIVE_URL", default=None)


### PR DESCRIPTION
This should let you run [primitive](https://github.com/fogleman/primitive/) on posted images by replying to them with `primrose` or `primrose m=3` or `primrose n=64` (or both `m` and `n`), where `m` is shape

    # shape: 0=combo 1=triangle 2=rect 3=ellipse 4=circle 5=rotatedrect
    # 6=beziers 7=rotatedellipse 8=polygon

and `n` is number of shapes. Defaults for the underlying API are those of the program itself, 1 and 128. The API in question is https://github.com/bensteinberg/primitive-api and is intended to be used in this context via a Dokku plugin, https://github.com/bensteinberg/dokku-primitive.

I plan to update the README once I see this working :)